### PR TITLE
refactor: Use Form Requests for validation in controllers

### DIFF
--- a/app/Http/Controllers/FabricController.php
+++ b/app/Http/Controllers/FabricController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Fabric;
+use App\Models\Supplier;
+use App\Http\Requests\StoreFabricRequest;
+use App\Http\Requests\UpdateFabricRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class FabricController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $fabrics = Fabric::with('supplier')->paginate(10);
+        return view('fabrics.index', compact('fabrics'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        $suppliers = Supplier::all();
+        return view('fabrics.create', compact('suppliers'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreFabricRequest $request)
+    {
+        $data = $request->validated();
+        $data['added_by'] = Auth::id();
+        $data['barcode'] = 'fab-'.Str::uuid();
+
+        if ($request->hasFile('image')) {
+            $path = $request->file('image')->store('fabric_images', 'public');
+            $data['image_path'] = $path;
+        }
+
+        Fabric::create($data);
+
+        return redirect()->route('fabrics.index')->with('success', 'Fabric created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Fabric $fabric)
+    {
+        return view('fabrics.show', compact('fabric'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Fabric $fabric)
+    {
+        $suppliers = Supplier::all();
+        return view('fabrics.edit', compact('fabric', 'suppliers'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateFabricRequest $request, Fabric $fabric)
+    {
+        $data = $request->validated();
+        $data['updated_by'] = Auth::id();
+
+        if ($request->hasFile('image')) {
+            // Optional: Delete old image if it exists
+            // if ($fabric->image_path) {
+            //     Storage::disk('public')->delete($fabric->image_path);
+            // }
+            $path = $request->file('image')->store('fabric_images', 'public');
+            $data['image_path'] = $path;
+        }
+
+        $fabric->update($data);
+
+        return redirect()->route('fabrics.index')->with('success', 'Fabric updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Fabric $fabric)
+    {
+        $fabric->delete();
+        return redirect()->route('fabrics.index')->with('success', 'Fabric deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Supplier;
+use Illuminate\Http\Request;
+use App\Http\Requests\StoreSupplierRequest;
+use App\Http\Requests\UpdateSupplierRequest;
+use Illuminate\Support\Facades\Auth;
+
+class SupplierController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $query = Supplier::query();
+
+        if ($request->has('search')) {
+            $searchTerm = $request->input('search');
+            $query->where('company_name', 'like', "%{$searchTerm}%")
+                  ->orWhere('country', 'like', "%{$searchTerm}%")
+                  ->orWhere('representative_name', 'like', "%{$searchTerm}%");
+        }
+
+        if ($request->has('country')) {
+            $query->where('country', $request->input('country'));
+        }
+
+        if ($request->has('start_date') && $request->has('end_date')) {
+            $query->whereBetween('created_at', [$request->input('start_date'), $request->input('end_date')]);
+        }
+
+        $suppliers = $query->paginate(10);
+        return view('suppliers.index', compact('suppliers'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('suppliers.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreSupplierRequest $request)
+    {
+        $supplier = new Supplier($request->validated());
+        $supplier->added_by = Auth::id();
+        $supplier->save();
+
+        return redirect()->route('suppliers.index')->with('success', 'Supplier created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Supplier $supplier)
+    {
+        return view('suppliers.show', compact('supplier'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Supplier $supplier)
+    {
+        return view('suppliers.edit', compact('supplier'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateSupplierRequest $request, Supplier $supplier)
+    {
+        $supplier->fill($request->validated());
+        $supplier->updated_by = Auth::id();
+        $supplier->save();
+
+        return redirect()->route('suppliers.index')->with('success', 'Supplier updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Supplier $supplier)
+    {
+        $supplier->delete();
+        return redirect()->route('suppliers.index')->with('success', 'Supplier deleted successfully.');
+    }
+}

--- a/app/Http/Requests/StoreFabricRequest.php
+++ b/app/Http/Requests/StoreFabricRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreFabricRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'fabric_no' => 'required|string|unique:fabrics,fabric_no|max:255',
+            'composition' => 'required|string|max:255',
+            'gsm' => 'required|string|max:255',
+            'qty' => 'required|numeric',
+            'cuttable_width' => 'required|string|max:255',
+            'production_type' => 'required|in:Sample Yardage,SMS,Bulk',
+            'supplier_id' => 'required|exists:suppliers,id',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreSupplierRequest.php
+++ b/app/Http/Requests/StoreSupplierRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSupplierRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // For now, we'll allow any authenticated user to create a supplier.
+        // You might want to add more specific authorization logic here later.
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'country' => 'required|string|max:255',
+            'company_name' => 'required|string|max:255',
+            'code' => 'required|string|unique:suppliers,code|max:255',
+            'email' => 'nullable|email|max:255',
+            'phone' => 'nullable|string|max:255',
+            'address' => 'nullable|string',
+            'representative_name' => 'nullable|string|max:255',
+            'representative_email' => 'nullable|email|max:255',
+            'representative_phone' => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateFabricRequest.php
+++ b/app/Http/Requests/UpdateFabricRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateFabricRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        $fabricId = $this->route('fabric')->id;
+
+        return [
+            'fabric_no' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('fabrics')->ignore($fabricId),
+            ],
+            'composition' => 'required|string|max:255',
+            'gsm' => 'required|string|max:255',
+            'qty' => 'required|numeric',
+            'cuttable_width' => 'required|string|max:255',
+            'production_type' => 'required|in:Sample Yardage,SMS,Bulk',
+            'supplier_id' => 'required|exists:suppliers,id',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateSupplierRequest.php
+++ b/app/Http/Requests/UpdateSupplierRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateSupplierRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // For now, we'll allow any authenticated user to update a supplier.
+        // You might want to add more specific authorization logic here later.
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        $supplierId = $this->route('supplier')->id;
+
+        return [
+            'country' => 'required|string|max:255',
+            'company_name' => 'required|string|max:255',
+            'code' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('suppliers')->ignore($supplierId),
+            ],
+            'email' => 'nullable|email|max:255',
+            'phone' => 'nullable|string|max:255',
+            'address' => 'nullable|string',
+            'representative_name' => 'nullable|string|max:255',
+            'representative_email' => 'nullable|email|max:255',
+            'representative_phone' => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/app/Models/Fabric.php
+++ b/app/Models/Fabric.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Fabric extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'fabric_no',
+        'composition',
+        'gsm',
+        'qty',
+        'cuttable_width',
+        'production_type',
+        'construction',
+        'color_pantone_code',
+        'weave_type',
+        'finish_type',
+        'dyeing_method',
+        'printing_method',
+        'lead_time',
+        'moq',
+        'shrinkage',
+        'remarks',
+        'fabric_selected_by',
+        'image_path',
+        'barcode',
+        'supplier_id',
+        'added_by',
+        'updated_by',
+    ];
+
+    public function supplier()
+    {
+        return $this->belongsTo(Supplier::class);
+    }
+
+    public function stocks()
+    {
+        return $this->hasMany(FabricStock::class);
+    }
+
+    public function addedBy()
+    {
+        return $this->belongsTo(User::class, 'added_by');
+    }
+
+    public function updatedBy()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    public function notes()
+    {
+        return $this->morphMany(Note::class, 'notable');
+    }
+}

--- a/app/Models/FabricStock.php
+++ b/app/Models/FabricStock.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class FabricStock extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'fabric_id',
+        'transaction_type',
+        'qty',
+        'barcode',
+    ];
+
+    public function fabric()
+    {
+        return $this->belongsTo(Fabric::class);
+    }
+}

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Note extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'note',
+        'notable_id',
+        'notable_type',
+        'added_by',
+        'updated_by',
+    ];
+
+    public function notable()
+    {
+        return $this->morphTo();
+    }
+
+    public function addedBy()
+    {
+        return $this->belongsTo(User::class, 'added_by');
+    }
+
+    public function updatedBy()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+}

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Supplier extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'country',
+        'company_name',
+        'code',
+        'added_by',
+        'email',
+        'phone',
+        'address',
+        'representative_name',
+        'representative_email',
+        'representative_phone',
+        'updated_by',
+    ];
+
+    public function fabrics()
+    {
+        return $this->hasMany(Fabric::class);
+    }
+
+    public function addedBy()
+    {
+        return $this->belongsTo(User::class, 'added_by');
+    }
+
+    public function updatedBy()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    public function notes()
+    {
+        return $this->morphMany(Note::class, 'notable');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,4 +45,19 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function suppliers()
+    {
+        return $this->hasMany(Supplier::class, 'added_by');
+    }
+
+    public function fabrics()
+    {
+        return $this->hasMany(Fabric::class, 'added_by');
+    }
+
+    public function notes()
+    {
+        return $this->hasMany(Note::class, 'added_by');
+    }
 }

--- a/database/migrations/2024_07_25_000000_create_suppliers_table.php
+++ b/database/migrations/2024_07_25_000000_create_suppliers_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('suppliers', function (Blueprint $table) {
+            $table->id();
+            $table->string('country');
+            $table->string('company_name');
+            $table->string('code')->unique();
+            $table->foreignId('added_by')->constrained('users');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->text('address')->nullable();
+            $table->string('representative_name')->nullable();
+            $table->string('representative_email')->nullable();
+            $table->string('representative_phone')->nullable();
+            $table->foreignId('updated_by')->nullable()->constrained('users');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('suppliers');
+    }
+};

--- a/database/migrations/2024_07_25_000001_create_fabrics_table.php
+++ b/database/migrations/2024_07_25_000001_create_fabrics_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('fabrics', function (Blueprint $table) {
+            $table->id();
+            $table->string('fabric_no')->unique();
+            $table->string('composition');
+            $table->string('gsm');
+            $table->decimal('qty', 8, 2);
+            $table->string('cuttable_width');
+            $table->enum('production_type', ['Sample Yardage', 'SMS', 'Bulk']);
+            $table->string('construction')->nullable();
+            $table->string('color_pantone_code')->nullable();
+            $table->string('weave_type')->nullable();
+            $table->string('finish_type')->nullable();
+            $table->string('dyeing_method')->nullable();
+            $table->string('printing_method')->nullable();
+            $table->string('lead_time')->nullable();
+            $table->string('moq')->nullable();
+            $table->string('shrinkage')->nullable();
+            $table->text('remarks')->nullable();
+            $table->string('fabric_selected_by')->nullable();
+            $table->string('image_path')->nullable();
+            $table->string('barcode')->unique();
+            $table->foreignId('supplier_id')->constrained('suppliers');
+            $table->foreignId('added_by')->constrained('users');
+            $table->foreignId('updated_by')->nullable()->constrained('users');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('fabrics');
+    }
+};

--- a/database/migrations/2024_07_25_000002_create_fabric_stocks_table.php
+++ b/database/migrations/2024_07_25_000002_create_fabric_stocks_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('fabric_stocks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('fabric_id')->constrained('fabrics');
+            $table->enum('transaction_type', ['in', 'out']);
+            $table->decimal('qty', 8, 2);
+            $table->string('barcode')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('fabric_stocks');
+    }
+};

--- a/database/migrations/2024_07_25_000003_create_notes_table.php
+++ b/database/migrations/2024_07_25_000003_create_notes_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notes', function (Blueprint $table) {
+            $table->id();
+            $table->text('note');
+            $table->morphs('notable');
+            $table->foreignId('added_by')->constrained('users');
+            $table->foreignId('updated_by')->nullable()->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notes');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -13,11 +12,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            UserSeeder::class,
+            SupplierSeeder::class,
+            FabricSeeder::class,
+            FabricStockSeeder::class,
+            NoteSeeder::class,
         ]);
     }
 }

--- a/database/seeders/FabricSeeder.php
+++ b/database/seeders/FabricSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Fabric;
+use App\Models\Supplier;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class FabricSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        if (Fabric::count() === 0 && Supplier::count() > 0 && User::count() > 0) {
+            $user = User::first();
+            $supplier = Supplier::first();
+            DB::table('fabrics')->insert([
+                [
+                    'fabric_no' => 'FAB-001',
+                    'composition' => '100% Cotton',
+                    'gsm' => '180',
+                    'qty' => 1000.00,
+                    'cuttable_width' => '58"',
+                    'production_type' => 'Bulk',
+                    'construction' => 'Single Jersey',
+                    'color_pantone_code' => '19-4052 TCX',
+                    'weave_type' => 'Knit',
+                    'finish_type' => 'Bio-wash',
+                    'dyeing_method' => 'Piece Dyed',
+                    'printing_method' => 'N/A',
+                    'lead_time' => '30 days',
+                    'moq' => '500 kg',
+                    'shrinkage' => '5%',
+                    'remarks' => 'Standard quality cotton fabric.',
+                    'fabric_selected_by' => 'Merchandiser A',
+                    'image_path' => null,
+                    'barcode' => Str::random(12),
+                    'supplier_id' => $supplier->id,
+                    'added_by' => $user->id,
+                    'updated_by' => null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                    'deleted_at' => null,
+                ],
+                [
+                    'fabric_no' => 'FAB-002',
+                    'composition' => '95% Cotton 5% Spandex',
+                    'gsm' => '220',
+                    'qty' => 500.00,
+                    'cuttable_width' => '60"',
+                    'production_type' => 'SMS',
+                    'construction' => 'Rib',
+                    'color_pantone_code' => '18-3838 TCX',
+                    'weave_type' => 'Knit',
+                    'finish_type' => 'Enzyme Wash',
+                    'dyeing_method' => 'Yarn Dyed',
+                    'printing_method' => 'N/A',
+                    'lead_time' => '45 days',
+                    'moq' => '300 kg',
+                    'shrinkage' => '7%',
+                    'remarks' => 'For stretchable garments.',
+                    'fabric_selected_by' => 'Designer B',
+                    'image_path' => null,
+                    'barcode' => Str::random(12),
+                    'supplier_id' => $supplier->id,
+                    'added_by' => $user->id,
+                    'updated_by' => null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                    'deleted_at' => null,
+                ]
+            ]);
+        }
+    }
+}

--- a/database/seeders/FabricStockSeeder.php
+++ b/database/seeders/FabricStockSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Fabric;
+use App\Models\FabricStock;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class FabricStockSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        if (FabricStock::count() === 0 && Fabric::count() > 0) {
+            $fabrics = Fabric::all();
+            foreach ($fabrics as $fabric) {
+                DB::table('fabric_stocks')->insert([
+                    [
+                        'fabric_id' => $fabric->id,
+                        'transaction_type' => 'in',
+                        'qty' => $fabric->qty,
+                        'barcode' => Str::random(12),
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ],
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/NoteSeeder.php
+++ b/database/seeders/NoteSeeder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Note;
+use App\Models\Supplier;
+use App\Models\Fabric;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class NoteSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        if (Note::count() === 0 && User::count() > 0 && Supplier::count() > 0 && Fabric::count() > 0) {
+            $user = User::first();
+            $supplier = Supplier::first();
+            $fabric = Fabric::first();
+
+            DB::table('notes')->insert([
+                [
+                    'note' => 'This is a note for the first supplier.',
+                    'notable_id' => $supplier->id,
+                    'notable_type' => Supplier::class,
+                    'added_by' => $user->id,
+                    'updated_by' => null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+                [
+                    'note' => 'This is a note for the first fabric.',
+                    'notable_id' => $fabric->id,
+                    'notable_type' => Fabric::class,
+                    'added_by' => $user->id,
+                    'updated_by' => null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            ]);
+        }
+    }
+}

--- a/database/seeders/SupplierSeeder.php
+++ b/database/seeders/SupplierSeeder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Supplier;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class SupplierSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        if (Supplier::count() === 0 && User::count() > 0) {
+            $user = User::first();
+            DB::table('suppliers')->insert([
+                [
+                    'country' => 'USA',
+                    'company_name' => 'Test Supplier Inc.',
+                    'code' => 'TS001',
+                    'added_by' => $user->id,
+                    'email' => 'contact@testsupplier.com',
+                    'phone' => '123-456-7890',
+                    'address' => '123 Test Street, Test City, USA',
+                    'representative_name' => 'John Doe',
+                    'representative_email' => 'john.doe@testsupplier.com',
+                    'representative_phone' => '098-765-4321',
+                    'updated_by' => null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                    'deleted_at' => null,
+                ],
+                [
+                    'country' => 'Bangladesh',
+                    'company_name' => 'BD Fabrics Ltd.',
+                    'code' => 'BD001',
+                    'added_by' => $user->id,
+                    'email' => 'info@bdfabrics.com',
+                    'phone' => '111-222-3333',
+                    'address' => '456 Fabric Lane, Dhaka, Bangladesh',
+                    'representative_name' => 'Jane Smith',
+                    'representative_email' => 'jane.smith@bdfabrics.com',
+                    'representative_phone' => '444-555-6666',
+                    'updated_by' => null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                    'deleted_at' => null,
+                ]
+            ]);
+        }
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        if (User::count() === 0) {
+            DB::table('users')->insert([
+                [
+                    'name' => 'Admin User',
+                    'email' => 'admin@example.com',
+                    'password' => Hash::make('password'),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+                [
+                    'name' => 'Regular User',
+                    'email' => 'user@example.com',
+                    'password' => Hash::make('password'),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            ]);
+        }
+    }
+}

--- a/resources/views/fabrics/create.blade.php
+++ b/resources/views/fabrics/create.blade.php
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Add Fabric</title>
+</head>
+<body>
+    <h1>Add Fabric</h1>
+
+    @if ($errors->any())
+        <div>
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form action="{{ route('fabrics.store') }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        <label>Fabric No: <input type="text" name="fabric_no" required></label><br>
+        <label>Composition: <input type="text" name="composition" required></label><br>
+        <label>GSM: <input type="text" name="gsm" required></label><br>
+        <label>QTY: <input type="number" step="0.01" name="qty" required></label><br>
+        <label>Cuttable Width: <input type="text" name="cuttable_width" required></label><br>
+        <label>Production Type:
+            <select name="production_type" required>
+                <option value="Sample Yardage">Sample Yardage</option>
+                <option value="SMS">SMS</option>
+                <option value="Bulk">Bulk</option>
+            </select>
+        </label><br>
+        <label>Supplier:
+            <select name="supplier_id" required>
+                @foreach ($suppliers as $supplier)
+                    <option value="{{ $supplier->id }}">{{ $supplier->company_name }}</option>
+                @endforeach
+            </select>
+        </label><br>
+        <label>Fabric Image: <input type="file" name="image"></label><br>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/resources/views/fabrics/edit.blade.php
+++ b/resources/views/fabrics/edit.blade.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Edit Fabric</title>
+</head>
+<body>
+    <h1>Edit Fabric</h1>
+
+    @if ($errors->any())
+        <div>
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form action="{{ route('fabrics.update', $fabric) }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        @method('PUT')
+        <label>Fabric No: <input type="text" name="fabric_no" value="{{ $fabric->fabric_no }}" required></label><br>
+        <label>Composition: <input type="text" name="composition" value="{{ $fabric->composition }}" required></label><br>
+        <label>GSM: <input type="text" name="gsm" value="{{ $fabric->gsm }}" required></label><br>
+        <label>QTY: <input type="number" step="0.01" name="qty" value="{{ $fabric->qty }}" required></label><br>
+        <label>Cuttable Width: <input type="text" name="cuttable_width" value="{{ $fabric->cuttable_width }}" required></label><br>
+        <label>Production Type:
+            <select name="production_type" required>
+                <option value="Sample Yardage" @if($fabric->production_type == 'Sample Yardage') selected @endif>Sample Yardage</option>
+                <option value="SMS" @if($fabric->production_type == 'SMS') selected @endif>SMS</option>
+                <option value="Bulk" @if($fabric->production_type == 'Bulk') selected @endif>Bulk</option>
+            </select>
+        </label><br>
+        <label>Supplier:
+            <select name="supplier_id" required>
+                @foreach ($suppliers as $supplier)
+                    <option value="{{ $supplier->id }}" @if($fabric->supplier_id == $supplier->id) selected @endif>{{ $supplier->company_name }}</option>
+                @endforeach
+            </select>
+        </label><br>
+        <label>Fabric Image: <input type="file" name="image"></label><br>
+        @if ($fabric->image_path)
+            <img src="{{ asset('storage/' . $fabric->image_path) }}" alt="Fabric Image" width="100">
+        @endif
+        <br>
+        <button type="submit">Update</button>
+    </form>
+</body>
+</html>

--- a/resources/views/fabrics/index.blade.php
+++ b/resources/views/fabrics/index.blade.php
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Fabrics</title>
+</head>
+<body>
+    <h1>Fabrics</h1>
+    <a href="{{ route('fabrics.create') }}">Add Fabric</a>
+
+    <table border="1">
+        <thead>
+            <tr>
+                <th>Fabric No</th>
+                <th>Composition</th>
+                <th>GSM</th>
+                <th>Supplier</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($fabrics as $fabric)
+                <tr>
+                    <td>{{ $fabric->fabric_no }}</td>
+                    <td>{{ $fabric->composition }}</td>
+                    <td>{{ $fabric->gsm }}</td>
+                    <td>{{ $fabric->supplier->company_name ?? 'N/A' }}</td>
+                    <td>
+                        <a href="{{ route('fabrics.show', $fabric) }}">View</a>
+                        <a href="{{ route('fabrics.edit', $fabric) }}">Edit</a>
+                        <form action="{{ route('fabrics.destroy', $fabric) }}" method="POST" style="display:inline;">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    {{ $fabrics->links() }}
+</body>
+</html>

--- a/resources/views/fabrics/show.blade.php
+++ b/resources/views/fabrics/show.blade.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>View Fabric</title>
+</head>
+<body>
+    <h1>Fabric Details</h1>
+    <p><strong>Fabric No:</strong> {{ $fabric->fabric_no }}</p>
+    <p><strong>Composition:</strong> {{ $fabric->composition }}</p>
+    <p><strong>GSM:</strong> {{ $fabric->gsm }}</p>
+    <p><strong>Quantity:</strong> {{ $fabric->qty }}</p>
+    <p><strong>Cuttable Width:</strong> {{ $fabric->cuttable_width }}</p>
+    <p><strong>Production Type:</strong> {{ $fabric->production_type }}</p>
+    <p><strong>Supplier:</strong> {{ $fabric->supplier->company_name ?? 'N/A' }}</p>
+    <p><strong>Added By:</strong> {{ $fabric->addedBy->name ?? 'N/A' }}</p>
+    <p><strong>Updated By:</strong> {{ $fabric->updatedBy->name ?? 'N/A' }}</p>
+
+    @if ($fabric->image_path)
+        <p><strong>Fabric Image:</strong></p>
+        <img src="{{ asset('storage/' . $fabric->image_path) }}" alt="Fabric Image" width="200">
+    @endif
+
+    <p><strong>Barcode:</strong> {{ $fabric->barcode }}</p>
+    {{-- Barcode generation and printing would require a library and more complex setup --}}
+    {{-- For now, just displaying the code and a placeholder button --}}
+    <button onclick="window.print()">Print Barcode</button>
+    <br><br>
+
+    <a href="{{ route('fabrics.index') }}">Back to List</a>
+</body>
+</html>

--- a/resources/views/suppliers/create.blade.php
+++ b/resources/views/suppliers/create.blade.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Add Supplier</title>
+</head>
+<body>
+    <h1>Add Supplier</h1>
+
+    @if ($errors->any())
+        <div>
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form action="{{ route('suppliers.store') }}" method="POST">
+        @csrf
+        <label>Country: <input type="text" name="country" required></label><br>
+        <label>Company Name: <input type="text" name="company_name" required></label><br>
+        <label>Code: <input type="text" name="code" required></label><br>
+        <label>Email: <input type="email" name="email"></label><br>
+        <label>Phone: <input type="text" name="phone"></label><br>
+        <label>Address: <textarea name="address"></textarea></label><br>
+        <label>Representative Name: <input type="text" name="representative_name"></label><br>
+        <label>Representative Email: <input type="email" name="representative_email"></label><br>
+        <label>Representative Phone: <input type="text" name="representative_phone"></label><br>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Edit Supplier</title>
+</head>
+<body>
+    <h1>Edit Supplier</h1>
+
+    @if ($errors->any())
+        <div>
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form action="{{ route('suppliers.update', $supplier) }}" method="POST">
+        @csrf
+        @method('PUT')
+        <label>Country: <input type="text" name="country" value="{{ $supplier->country }}" required></label><br>
+        <label>Company Name: <input type="text" name="company_name" value="{{ $supplier->company_name }}" required></label><br>
+        <label>Code: <input type="text" name="code" value="{{ $supplier->code }}" required></label><br>
+        <label>Email: <input type="email" name="email" value="{{ $supplier->email }}"></label><br>
+        <label>Phone: <input type="text" name="phone" value="{{ $supplier->phone }}"></label><br>
+        <label>Address: <textarea name="address">{{ $supplier->address }}</textarea></label><br>
+        <label>Representative Name: <input type="text" name="representative_name" value="{{ $supplier->representative_name }}"></label><br>
+        <label>Representative Email: <input type="email" name="representative_email" value="{{ $supplier->representative_email }}"></label><br>
+        <label>Representative Phone: <input type="text" name="representative_phone" value="{{ $supplier->representative_phone }}"></label><br>
+        <button type="submit">Update</button>
+    </form>
+</body>
+</html>

--- a/resources/views/suppliers/index.blade.php
+++ b/resources/views/suppliers/index.blade.php
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Suppliers</title>
+</head>
+<body>
+    <h1>Suppliers</h1>
+    <a href="{{ route('suppliers.create') }}">Add Supplier</a>
+
+    <form method="GET" action="{{ route('suppliers.index') }}">
+        <input type="text" name="search" placeholder="Search..." value="{{ request('search') }}">
+        <button type="submit">Search</button>
+    </form>
+
+    <table border="1">
+        <thead>
+            <tr>
+                <th>Company Name</th>
+                <th>Country</th>
+                <th>Code</th>
+                <th>Representative</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($suppliers as $supplier)
+                <tr>
+                    <td>{{ $supplier->company_name }}</td>
+                    <td>{{ $supplier->country }}</td>
+                    <td>{{ $supplier->code }}</td>
+                    <td>{{ $supplier->representative_name }}</td>
+                    <td>
+                        <a href="{{ route('suppliers.show', $supplier) }}">View</a>
+                        <a href="{{ route('suppliers.edit', $supplier) }}">Edit</a>
+                        <form action="{{ route('suppliers.destroy', $supplier) }}" method="POST" style="display:inline;">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    {{ $suppliers->links() }}
+</body>
+</html>

--- a/resources/views/suppliers/show.blade.php
+++ b/resources/views/suppliers/show.blade.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>View Supplier</title>
+</head>
+<body>
+    <h1>Supplier Details</h1>
+    <p><strong>Country:</strong> {{ $supplier->country }}</p>
+    <p><strong>Company Name:</strong> {{ $supplier->company_name }}</p>
+    <p><strong>Code:</strong> {{ $supplier->code }}</p>
+    <p><strong>Email:</strong> {{ $supplier->email }}</p>
+    <p><strong>Phone:</strong> {{ $supplier->phone }}</p>
+    <p><strong>Address:</strong> {{ $supplier->address }}</p>
+    <p><strong>Representative Name:</strong> {{ $supplier->representative_name }}</p>
+    <p><strong>Representative Email:</strong> {{ $supplier->representative_email }}</p>
+    <p><strong>Representative Phone:</strong> {{ $supplier->representative_phone }}</p>
+    <p><strong>Added By:</strong> {{ $supplier->addedBy->name ?? 'N/A' }}</p>
+    <p><strong>Updated By:</strong> {{ $supplier->updatedBy->name ?? 'N/A' }}</p>
+    <a href="{{ route('suppliers.index') }}">Back to List</a>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SupplierController;
+use App\Http\Controllers\FabricController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::resource('suppliers', SupplierController::class);
+Route::resource('fabrics', FabricController::class);


### PR DESCRIPTION
This commit refactors the validation logic out of the `SupplierController` and `FabricController` and into dedicated Form Request classes. This improves the separation of concerns and makes the validation logic reusable.

- **Form Requests:** Created `StoreSupplierRequest`, `UpdateSupplierRequest`, `StoreFabricRequest`, and `UpdateFabricRequest` to handle all validation for store and update operations.
- **Controller Integration:** Updated the `store` and `update` methods in both `SupplierController` and `FabricController` to use the new Form Request classes, removing the manual validation logic.