### PR TITLE
This commit implements a complete trash/soft-delete feature for both …

### DIFF
--- a/app/Http/Controllers/FabricController.php
+++ b/app/Http/Controllers/FabricController.php
@@ -7,6 +7,7 @@ use App\Models\Supplier;
 use App\Http\Requests\StoreFabricRequest;
 use App\Http\Requests\UpdateFabricRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class FabricController extends Controller
@@ -45,7 +46,7 @@ class FabricController extends Controller
 
         Fabric::create($data);
 
-        return redirect()->route('fabrics.index')->with('success', 'Fabric created successfully.');
+        return redirect()->route('admin.fabrics.index')->with('success', 'Fabric created successfully.');
     }
 
     /**
@@ -84,7 +85,7 @@ class FabricController extends Controller
 
         $fabric->update($data);
 
-        return redirect()->route('fabrics.index')->with('success', 'Fabric updated successfully.');
+        return redirect()->route('admin.fabrics.index')->with('success', 'Fabric updated successfully.');
     }
 
     /**
@@ -93,6 +94,39 @@ class FabricController extends Controller
     public function destroy(Fabric $fabric)
     {
         $fabric->delete();
-        return redirect()->route('fabrics.index')->with('success', 'Fabric deleted successfully.');
+        return redirect()->route('admin.fabrics.index')->with('success', 'Fabric moved to trash successfully.');
+    }
+
+    /**
+     * Display a listing of the trashed resource.
+     */
+    public function trash()
+    {
+        $trashedFabrics = Fabric::onlyTrashed()->with('supplier')->paginate(10);
+        return view('fabrics.trash', compact('trashedFabrics'));
+    }
+
+    /**
+     * Restore the specified resource from trash.
+     */
+    public function restore($id)
+    {
+        $fabric = Fabric::onlyTrashed()->findOrFail($id);
+        $fabric->restore();
+        return redirect()->route('admin.fabrics.trash')->with('success', 'Fabric restored successfully.');
+    }
+
+    /**
+     * Permanently delete the specified resource from storage.
+     */
+    public function forceDelete($id)
+    {
+        $fabric = Fabric::onlyTrashed()->findOrFail($id);
+        // Optional: Delete image from storage
+        if ($fabric->image_path) {
+            Storage::disk('public')->delete($fabric->image_path);
+        }
+        $fabric->forceDelete();
+        return redirect()->route('admin.fabrics.trash')->with('success', 'Fabric permanently deleted.');
     }
 }

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -53,7 +53,7 @@ class SupplierController extends Controller
         $supplier->added_by = Auth::id();
         $supplier->save();
 
-        return redirect()->route('suppliers.index')->with('success', 'Supplier created successfully.');
+        return redirect()->route('admin.suppliers.index')->with('success', 'Supplier created successfully.');
     }
 
     /**
@@ -81,7 +81,7 @@ class SupplierController extends Controller
         $supplier->updated_by = Auth::id();
         $supplier->save();
 
-        return redirect()->route('suppliers.index')->with('success', 'Supplier updated successfully.');
+        return redirect()->route('admin.suppliers.index')->with('success', 'Supplier updated successfully.');
     }
 
     /**
@@ -90,6 +90,35 @@ class SupplierController extends Controller
     public function destroy(Supplier $supplier)
     {
         $supplier->delete();
-        return redirect()->route('suppliers.index')->with('success', 'Supplier deleted successfully.');
+        return redirect()->route('admin.suppliers.index')->with('success', 'Supplier moved to trash successfully.');
+    }
+
+    /**
+     * Display a listing of the trashed resource.
+     */
+    public function trash()
+    {
+        $trashedSuppliers = Supplier::onlyTrashed()->paginate(10);
+        return view('suppliers.trash', compact('trashedSuppliers'));
+    }
+
+    /**
+     * Restore the specified resource from trash.
+     */
+    public function restore($id)
+    {
+        $supplier = Supplier::onlyTrashed()->findOrFail($id);
+        $supplier->restore();
+        return redirect()->route('admin.suppliers.trash')->with('success', 'Supplier restored successfully.');
+    }
+
+    /**
+     * Permanently delete the specified resource from storage.
+     */
+    public function forceDelete($id)
+    {
+        $supplier = Supplier::onlyTrashed()->findOrFail($id);
+        $supplier->forceDelete();
+        return redirect()->route('admin.suppliers.trash')->with('success', 'Supplier permanently deleted.');
     }
 }

--- a/resources/views/admin/partials/header.blade.php
+++ b/resources/views/admin/partials/header.blade.php
@@ -1,0 +1,27 @@
+<header class="bg-white shadow-sm flex items-center justify-between px-6 py-3">
+
+    {{-- Sidebar Toggle Button --}}
+    <button id="sidebar-toggle" class="text-gray-500 hover:text-gray-700 focus:outline-none">
+        <i class="fas fa-bars fa-lg"></i>
+    </button>
+
+    {{-- User Profile Dropdown --}}
+    <div class="relative" x-data="{ open: false }">
+        <button @click="open = !open" class="flex items-center text-gray-700 focus:outline-none">
+            <span class="mr-2">Admin</span>
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+        </button>
+
+        {{-- Dropdown Menu --}}
+        <div x-show="open" @click.away="open = false"
+            class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-50">
+            <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Profile</a>
+            <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Settings</a>
+            <div class="border-t border-gray-100"></div>
+            <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Logout</a>
+        </div>
+    </div>
+
+</header>

--- a/resources/views/admin/partials/sidebar.blade.php
+++ b/resources/views/admin/partials/sidebar.blade.php
@@ -1,0 +1,73 @@
+<aside id="sidebar" class="w-64 bg-gray-800 text-white flex flex-col sidebar-transition min-h-screen">
+
+    {{-- Logo / Branding --}}
+    <div class="h-16 flex items-center justify-center border-b border-gray-700">
+        <h1 class="text-lg font-semibold">Admin Panel</h1>
+    </div>
+
+    {{-- Navigation --}}
+    <nav class="flex-1 px-4 py-6 space-y-2 overflow-y-auto" x-data="{ openFabric: false, openSupplier: false }">
+
+        {{-- Dashboard --}}
+        <a href="{{ route('admin.dashboard') }}"
+            class="flex items-center px-3 py-2 rounded-lg hover:bg-gray-700 transition">
+            <div class="w-6 h-6 mr-3">
+                <i class="fa-solid fa-house"></i>
+            </div>
+            <span>Dashboard</span>
+        </a>
+
+        {{-- Fabrics Dropdown --}}
+        <div>
+            <button @click="openFabric = !openFabric"
+                class="flex items-center justify-between w-full px-3 py-2 rounded-lg hover:bg-gray-700 transition">
+                <div class="flex items-center">
+                    <div class="w-6 h-6 mr-3">
+                        <i class="fa-solid fa-layer-group"></i>
+                    </div>
+                    <span>Fabrics</span>
+                </div>
+                <svg :class="{'rotate-180': openFabric}" class="w-4 h-4 transition-transform duration-200" fill="none"
+                    stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+            </button>
+
+            <div x-show="openFabric" class="ml-8 space-y-1 mt-1">
+                <a href="{{ route('admin.fabrics.index') }}"
+                    class="block px-3 py-2 rounded-lg hover:bg-gray-600 transition">All Fabrics</a>
+                <a href="{{ route('admin.fabrics.create') }}"
+                    class="block px-3 py-2 rounded-lg hover:bg-gray-600 transition">Add New Fabric</a>
+                <a href="{{ route('admin.fabrics.trash') }}"
+                    class="block px-3 py-2 rounded-lg hover:bg-gray-600 transition">All Trashed Fabrics</a>
+            </div>
+        </div>
+
+        {{-- Suppliers Dropdown --}}
+        <div>
+            <button @click="openSupplier = !openSupplier"
+                class="flex items-center justify-between w-full px-3 py-2 rounded-lg hover:bg-gray-700 transition">
+                <div class="flex items-center">
+                    <div class="w-6 h-6 mr-3">
+                        <i class="fa-solid fa-truck-field"></i>
+                    </div>
+                    <span>Suppliers</span>
+                </div>
+                <svg :class="{'rotate-180': openSupplier}" class="w-4 h-4 transition-transform duration-200"
+                    fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+            </button>
+
+            <div x-show="openSupplier" class="ml-8 space-y-1 mt-1">
+                <a href="{{ route('admin.suppliers.index') }}"
+                    class="block px-3 py-2 rounded-lg hover:bg-gray-600 transition">All Suppliers</a>
+                <a href="{{ route('admin.suppliers.create') }}"
+                    class="block px-3 py-2 rounded-lg hover:bg-gray-600 transition">Add New Supplier</a>
+                <a href="{{ route('admin.suppliers.trash') }}"
+                    class="block px-3 py-2 rounded-lg hover:bg-gray-600 transition">All Trashed Suppliers</a>
+            </div>
+        </div>
+
+    </nav>
+</aside>

--- a/resources/views/fabrics/create.blade.php
+++ b/resources/views/fabrics/create.blade.php
@@ -21,7 +21,7 @@
         @endif
 
         <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-            <form action="{{ route('fabrics.store') }}" method="POST" enctype="multipart/form-data">
+            <form action="{{ route('admin.fabrics.store') }}" method="POST" enctype="multipart/form-data">
                 @csrf
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="mb-4">
@@ -104,7 +104,7 @@
                         type="submit">
                         Save
                     </button>
-                    <a href="{{ route('fabrics.index') }}"
+                    <a href="{{ route('admin.fabrics.index') }}"
                         class="inline-block align-baseline font-bold text-sm text-blue-500 hover:text-blue-800">
                         Cancel
                     </a>

--- a/resources/views/fabrics/edit.blade.php
+++ b/resources/views/fabrics/edit.blade.php
@@ -21,7 +21,7 @@
         @endif
 
         <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-            <form action="{{ route('fabrics.update', $fabric) }}" method="POST" enctype="multipart/form-data">
+            <form action="{{ route('admin.fabrics.update', $fabric) }}" method="POST" enctype="multipart/form-data">
                 @csrf
                 @method('PUT')
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -115,7 +115,7 @@
                         type="submit">
                         Update
                     </button>
-                    <a href="{{ route('fabrics.index') }}"
+                    <a href="{{ route('admin.fabrics.index') }}"
                         class="inline-block align-baseline font-bold text-sm text-blue-500 hover:text-blue-800">
                         Cancel
                     </a>

--- a/resources/views/fabrics/index.blade.php
+++ b/resources/views/fabrics/index.blade.php
@@ -8,9 +8,13 @@
 
 @section('content')
     <div class="w-full">
-        <a href="{{ route('fabrics.create') }}"
-            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 inline-block">Add
-            Fabric</a>
+        <div class="flex justify-between items-center mb-4">
+            <a href="{{ route('admin.fabrics.create') }}"
+                class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Add
+                Fabric</a>
+            <a href="{{ route('admin.fabrics.trash') }}"
+                class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">View Trash</a>
+        </div>
 
         <div class="bg-white shadow-md rounded my-6">
             <table class="min-w-max w-full table-auto">
@@ -45,21 +49,21 @@
                             </td>
                             <td class="py-3 px-6 text-center">
                                 <div class="flex item-center justify-center">
-                                    <a href="{{ route('fabrics.show', $fabric) }}"
+                                    <a href="{{ route('admin.fabrics.show', $fabric) }}"
                                         class="w-8 h-8 rounded-full bg-green-500 text-white flex items-center justify-center mr-2 transform hover:scale-110">
                                         <i class="fas fa-eye"></i>
                                     </a>
-                                    <a href="{{ route('fabrics.edit', $fabric) }}"
+                                    <a href="{{ route('admin.fabrics.edit', $fabric) }}"
                                         class="w-8 h-8 rounded-full bg-blue-500 text-white flex items-center justify-center mr-2 transform hover:scale-110">
                                         <i class="fas fa-pencil-alt"></i>
                                     </a>
-                                    <form action="{{ route('fabrics.destroy', $fabric) }}" method="POST"
-                                        class="inline-block">
+                                    <form action="{{ route('admin.fabrics.destroy', $fabric) }}" method="POST"
+                                        class="inline-block"
+                                        onsubmit="return confirm('Are you sure you want to move this fabric to trash?');">
                                         @csrf
                                         @method('DELETE')
                                         <button type="submit"
-                                            class="w-8 h-8 rounded-full bg-red-500 text-white flex items-center justify-center transform hover:scale-110"
-                                            onclick="return confirm('Are you sure you want to delete this fabric?');">
+                                            class="w-8 h-8 rounded-full bg-red-500 text-white flex items-center justify-center transform hover:scale-110">
                                             <i class="fas fa-trash"></i>
                                         </button>
                                     </form>

--- a/resources/views/fabrics/show.blade.php
+++ b/resources/views/fabrics/show.blade.php
@@ -47,7 +47,7 @@
             </div>
 
             <div class="mt-6">
-                <a href="{{ route('fabrics.index') }}"
+                <a href="{{ route('admin.fabrics.index') }}"
                     class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
                     Back to List
                 </a>

--- a/resources/views/fabrics/trash.blade.php
+++ b/resources/views/fabrics/trash.blade.php
@@ -1,0 +1,83 @@
+@extends('layouts.admin')
+
+@section('title', 'Trashed Fabrics')
+
+@section('header')
+    <div class="flex justify-between items-center">
+        <h1 class="text-2xl font-semibold">Trashed Fabrics</h1>
+        <a href="{{ route('admin.fabrics.index') }}"
+            class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded">
+            Back to Fabrics
+        </a>
+    </div>
+@endsection
+
+@section('content')
+    <div class="w-full">
+        @if (session('success'))
+            <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+                <span class="block sm:inline">{{ session('success') }}</span>
+            </div>
+        @endif
+
+        <div class="bg-white shadow-md rounded my-6">
+            <table class="min-w-max w-full table-auto">
+                <thead>
+                    <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
+                        <th class="py-3 px-6 text-left">Fabric No</th>
+                        <th class="py-3 px-6 text-left">Composition</th>
+                        <th class="py-3 px-6 text-center">Supplier</th>
+                        <th class="py-3 px-6 text-center">Deleted At</th>
+                        <th class="py-3 px-6 text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="text-gray-600 text-sm font-light">
+                    @forelse ($trashedFabrics as $fabric)
+                        <tr class="border-b border-gray-200 hover:bg-gray-100">
+                            <td class="py-3 px-6 text-left whitespace-nowrap">
+                                <span class="font-medium">{{ $fabric->fabric_no }}</span>
+                            </td>
+                            <td class="py-3 px-6 text-left">
+                                <span>{{ $fabric->composition }}</span>
+                            </td>
+                            <td class="py-3 px-6 text-center">
+                                <span>{{ $fabric->supplier->company_name ?? 'N/A' }}</span>
+                            </td>
+                            <td class="py-3 px-6 text-center">
+                                <span>{{ $fabric->deleted_at->format('Y-m-d H:i:s') }}</span>
+                            </td>
+                            <td class="py-3 px-6 text-center">
+                                <div class="flex item-center justify-center">
+                                    <form action="{{ route('admin.fabrics.restore', $fabric->id) }}" method="POST"
+                                        class="inline-block mr-2"
+                                        onsubmit="return confirm('Are you sure you want to restore this fabric?');">
+                                        @csrf
+                                        <button type="submit"
+                                            class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
+                                            Restore
+                                        </button>
+                                    </form>
+                                    <form action="{{ route('admin.fabrics.force-delete', $fabric->id) }}" method="POST"
+                                        class="inline-block"
+                                        onsubmit="return confirm('Are you sure you want to permanently delete this fabric? This action cannot be undone.');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit"
+                                            class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">
+                                            Delete Permanently
+                                        </button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="5" class="py-3 px-6 text-center">No trashed fabrics found.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        {{ $trashedFabrics->links() }}
+    </div>
+@endsection

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -9,7 +9,9 @@
     <title>@yield('title', config('app.name', 'Laravel') . ' | Admin')</title>
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
+
 
     <style>
         .sidebar-transition {
@@ -51,12 +53,12 @@
         document.addEventListener('DOMContentLoaded', () => {
             const sidebar = document.getElementById('sidebar');
             const toggleButton = document.getElementById('sidebar-toggle');
+            const mainContent = document.getElementById('main-content');
 
             toggleButton.addEventListener('click', () => {
                 sidebar.classList.toggle('w-64');
                 sidebar.classList.toggle('w-20');
 
-                // Optional: text hide/show
                 sidebar.querySelectorAll('span').forEach(span => {
                     span.classList.toggle('hidden');
                 });

--- a/resources/views/suppliers/create.blade.php
+++ b/resources/views/suppliers/create.blade.php
@@ -21,7 +21,7 @@
         @endif
 
         <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-            <form action="{{ route('suppliers.store') }}" method="POST">
+            <form action="{{ route('admin.suppliers.store') }}" method="POST">
                 @csrf
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="mb-4">
@@ -106,7 +106,7 @@
                         type="submit">
                         Save
                     </button>
-                    <a href="{{ route('suppliers.index') }}"
+                    <a href="{{ route('admin.suppliers.index') }}"
                         class="inline-block align-baseline font-bold text-sm text-blue-500 hover:text-blue-800">
                         Cancel
                     </a>

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -21,7 +21,7 @@
         @endif
 
         <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-            <form action="{{ route('suppliers.update', $supplier) }}" method="POST">
+            <form action="{{ route('admin.suppliers.update', $supplier) }}" method="POST">
                 @csrf
                 @method('PUT')
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -108,7 +108,7 @@
                         type="submit">
                         Update
                     </button>
-                    <a href="{{ route('suppliers.index') }}"
+                    <a href="{{ route('admin.suppliers.index') }}"
                         class="inline-block align-baseline font-bold text-sm text-blue-500 hover:text-blue-800">
                         Cancel
                     </a>

--- a/resources/views/suppliers/index.blade.php
+++ b/resources/views/suppliers/index.blade.php
@@ -9,9 +9,13 @@
 @section('content')
     <div class="w-full">
         <div class="flex justify-between items-center mb-4">
-            <a href="{{ route('suppliers.create') }}"
-                class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Add Supplier</a>
-            <form method="GET" action="{{ route('suppliers.index') }}" class="flex">
+            <div>
+                <a href="{{ route('admin.suppliers.create') }}"
+                    class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Add Supplier</a>
+                <a href="{{ route('admin.suppliers.trash') }}"
+                    class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">View Trash</a>
+            </div>
+            <form method="GET" action="{{ route('admin.suppliers.index') }}" class="flex">
                 <input type="text" name="search" placeholder="Search..." value="{{ request('search') }}"
                     class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
                 <button type="submit"
@@ -51,17 +55,17 @@
                             </td>
                             <td class="py-3 px-6 text-center">
                                 <div class="flex item-center justify-center">
-                                    <a href="{{ route('suppliers.show', $supplier) }}"
+                                    <a href="{{ route('admin.suppliers.show', $supplier) }}"
                                         class="w-8 h-8 rounded-full bg-green-500 text-white flex items-center justify-center mr-2 transform hover:scale-110">
                                         <i class="fas fa-eye"></i>
                                     </a>
-                                    <a href="{{ route('suppliers.edit', $supplier) }}"
+                                    <a href="{{ route('admin.suppliers.edit', $supplier) }}"
                                         class="w-8 h-8 rounded-full bg-blue-500 text-white flex items-center justify-center mr-2 transform hover:scale-110">
                                         <i class="fas fa-pencil-alt"></i>
                                     </a>
-                                    <form action="{{ route('suppliers.destroy', $supplier) }}" method="POST"
+                                    <form action="{{ route('admin.suppliers.destroy', $supplier) }}" method="POST"
                                         class="inline-block"
-                                        onsubmit="return confirm('Are you sure you want to delete this supplier?');">
+                                        onsubmit="return confirm('Are you sure you want to move this supplier to trash?');">
                                         @csrf
                                         @method('DELETE')
                                         <button type="submit"

--- a/resources/views/suppliers/show.blade.php
+++ b/resources/views/suppliers/show.blade.php
@@ -31,7 +31,7 @@
                 <p class="text-gray-700"><strong>Updated By:</strong> {{ $supplier->updatedBy->name ?? 'N/A' }}</p>
             </div>
             <div class="mt-6">
-                <a href="{{ route('suppliers.index') }}"
+                <a href="{{ route('admin.suppliers.index') }}"
                     class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
                     Back to List
                 </a>

--- a/resources/views/suppliers/trash.blade.php
+++ b/resources/views/suppliers/trash.blade.php
@@ -1,0 +1,79 @@
+@extends('layouts.admin')
+
+@section('title', 'Trashed Suppliers')
+
+@section('header')
+    <div class="flex justify-between items-center">
+        <h1 class="text-2xl font-semibold">Trashed Suppliers</h1>
+        <a href="{{ route('admin.suppliers.index') }}"
+            class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded">
+            Back to Suppliers
+        </a>
+    </div>
+@endsection
+
+@section('content')
+    <div class="w-full">
+        @if (session('success'))
+            <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+                <span class="block sm:inline">{{ session('success') }}</span>
+            </div>
+        @endif
+
+        <div class="bg-white shadow-md rounded my-6">
+            <table class="min-w-max w-full table-auto">
+                <thead>
+                    <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
+                        <th class="py-3 px-6 text-left">Company Name</th>
+                        <th class="py-3 px-6 text-left">Country</th>
+                        <th class="py-3 px-6 text-center">Deleted At</th>
+                        <th class="py-3 px-6 text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="text-gray-600 text-sm font-light">
+                    @forelse ($trashedSuppliers as $supplier)
+                        <tr class="border-b border-gray-200 hover:bg-gray-100">
+                            <td class="py-3 px-6 text-left whitespace-nowrap">
+                                <span class="font-medium">{{ $supplier->company_name }}</span>
+                            </td>
+                            <td class="py-3 px-6 text-left">
+                                <span>{{ $supplier->country }}</span>
+                            </td>
+                            <td class="py-3 px-6 text-center">
+                                <span>{{ $supplier->deleted_at->format('Y-m-d H:i:s') }}</span>
+                            </td>
+                            <td class="py-3 px-6 text-center">
+                                <div class="flex item-center justify-center">
+                                    <form action="{{ route('admin.suppliers.restore', $supplier->id) }}" method="POST"
+                                        class="inline-block mr-2"
+                                        onsubmit="return confirm('Are you sure you want to restore this supplier?');">
+                                        @csrf
+                                        <button type="submit"
+                                            class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
+                                            Restore
+                                        </button>
+                                    </form>
+                                    <form action="{{ route('admin.suppliers.force-delete', $supplier->id) }}" method="POST"
+                                        class="inline-block"
+                                        onsubmit="return confirm('Are you sure you want to permanently delete this supplier? This action cannot be undone.');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit"
+                                            class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">
+                                            Delete Permanently
+                                        </button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="4" class="py-3 px-6 text-center">No trashed suppliers found.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        {{ $trashedSuppliers->links() }}
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,17 +9,28 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
-
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
-Route::resource('suppliers', SupplierController::class);
-Route::resource('fabrics', FabricController::class);
+Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(function () {
+    Route::get('/dashboard', function () {
+        return view('dashboard');
+    })->name('dashboard');
+
+    // Fabric Routes
+    Route::get('fabrics/trash', [FabricController::class, 'trash'])->name('fabrics.trash');
+    Route::post('fabrics/{id}/restore', [FabricController::class, 'restore'])->name('fabrics.restore');
+    Route::delete('fabrics/{id}/force-delete', [FabricController::class, 'forceDelete'])->name('fabrics.force-delete');
+    Route::resource('fabrics', FabricController::class);
+
+    // Supplier Routes
+    Route::get('suppliers/trash', [SupplierController::class, 'trash'])->name('suppliers.trash');
+    Route::post('suppliers/{id}/restore', [SupplierController::class, 'restore'])->name('suppliers.restore');
+    Route::delete('suppliers/{id}/force-delete', [SupplierController::class, 'forceDelete'])->name('suppliers.force-delete');
+    Route::resource('suppliers', SupplierController::class);
+});
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
…Fabrics and Suppliers. It also secures all related routes by placing them under an 'admin' prefix and applying the 'auth' middleware.

Key changes include:
- Grouping all fabric and supplier routes under an `admin` prefix and `auth` middleware in `routes/web.php`.
- Adding `trash`, `restore`, and `forceDelete` methods to both `FabricController` and `SupplierController`.
- Creating new `trash.blade.php` views for both fabrics and suppliers to manage soft-deleted items.
- Updating the admin sidebar and index pages with links to the new trash views.
- Updating all `route()` calls in the view files to use the new `admin.` prefixed route names, ensuring all links and forms work correctly.