### PR TITLE
feat: Add automatic user tracking to models

### DIFF
--- a/app/Models/Fabric.php
+++ b/app/Models/Fabric.php
@@ -82,4 +82,25 @@ class Fabric extends Model
         }
         return \App\Helpers\calculateFabricBalance($this->id);
     }
+
+    /**
+     * The "booted" method of the model.
+     * This will automatically populate user tracking fields.
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (auth()->check()) {
+                $model->added_by = auth()->id();
+            }
+        });
+
+        static::updating(function ($model) {
+            if (auth()->check()) {
+                $model->updated_by = auth()->id();
+            }
+        });
+    }
 }

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -53,4 +53,25 @@ class Supplier extends Model
     {
         return \Carbon\Carbon::parse($value)->format('d-m-Y H:i:s');
     }
+
+    /**
+     * The "booted" method of the model.
+     * This will automatically populate user tracking fields.
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (auth()->check()) {
+                $model->added_by = auth()->id();
+            }
+        });
+
+        static::updating(function ($model) {
+            if (auth()->check()) {
+                $model->updated_by = auth()->id();
+            }
+        });
+    }
 }


### PR DESCRIPTION
This commit introduces automatic user tracking to the `Supplier` and `Fabric` models to ensure that record creation and updates are properly attributed to a user.

- The `boot()` method has been added to both `app/Models/Supplier.php` and `app/Models/Fabric.php`.
- Eloquent's `creating` and `updating` model events are used to automatically set the `added_by` and `updated_by` fields with the authenticated user's ID.
- This approach centralizes the user-tracking logic in the models, adhering to Laravel best practices and improving code maintainability.