### PR TITLE
feat: Implement barcode system for Fabric module

### DIFF
--- a/app/Http/Controllers/FabricController.php
+++ b/app/Http/Controllers/FabricController.php
@@ -7,6 +7,7 @@ use App\Models\Supplier;
 use App\Http\Requests\StoreFabricRequest;
 use App\Http\Requests\UpdateFabricRequest;
 use App\Services\FabricService;
+use Illuminate\Http\Request;
 
 class FabricController extends Controller
 {
@@ -74,5 +75,10 @@ class FabricController extends Controller
     {
         $this->fabricService->forceDeleteFabric($id);
         return redirect()->route('admin.fabrics.trash')->with('success', 'Fabric permanently deleted.');
+    }
+
+    public function printBarcode(Fabric $fabric)
+    {
+        return view('fabrics.print', compact('fabric'));
     }
 }

--- a/app/Models/Fabric.php
+++ b/app/Models/Fabric.php
@@ -30,6 +30,7 @@ class Fabric extends Model
         'fabric_selected_by',
         'image_path',
         'barcode',
+        'barcode_no',
         'supplier_id',
         'added_by',
         'updated_by',

--- a/app/Services/FabricService.php
+++ b/app/Services/FabricService.php
@@ -23,7 +23,9 @@ class FabricService
 
     public function createFabric(array $data, $imageFile = null)
     {
-        $data['added_by'] = Auth::id();
+        // 'added_by' is handled by the Fabric model's boot method.
+
+        // The old barcode generation remains.
         $data['barcode'] = 'fab-' . Str::uuid();
 
         if ($imageFile) {
@@ -31,12 +33,19 @@ class FabricService
             $data['image_path'] = $path;
         }
 
-        return $this->fabricRepository->create($data);
+        // Create the fabric record.
+        $fabric = $this->fabricRepository->create($data);
+
+        // Generate barcode_no and save it to the record.
+        $fabric->barcode_no = 'FBR-' . str_pad($fabric->id, 6, '0', STR_PAD_LEFT);
+        $fabric->save();
+
+        return $fabric;
     }
 
     public function updateFabric(Fabric $fabric, array $data, $imageFile = null)
     {
-        $data['updated_by'] = Auth::id();
+        // 'updated_by' is handled by the Fabric model's boot method.
 
         if ($imageFile) {
             if ($fabric->image_path) {

--- a/database/migrations/2024_07_25_000004_add_barcode_no_to_fabrics_table.php
+++ b/database/migrations/2024_07_25_000004_add_barcode_no_to_fabrics_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('fabrics', function (Blueprint $table) {
+            $table->string('barcode_no')->unique()->nullable()->after('barcode');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('fabrics', function (Blueprint $table) {
+            $table->dropColumn('barcode_no');
+        });
+    }
+};

--- a/resources/views/fabrics/index.blade.php
+++ b/resources/views/fabrics/index.blade.php
@@ -75,6 +75,7 @@
             <thead>
                 <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
                     <th class="py-3 px-6 text-left">Fabric No</th>
+                    <th class="py-3 px-6 text-left">Barcode</th>
                     <th class="py-3 px-6 text-left">Composition</th>
                     <th class="py-3 px-6 text-center">GSM</th>
                     <th class="py-3 px-6 text-center">Supplier</th>
@@ -89,6 +90,14 @@
                         <div class="flex items-center">
                             <span class="font-medium">{{ $fabric->fabric_no }}</span>
                         </div>
+                    </td>
+                    <td class="py-3 px-6 text-left">
+                        @if($fabric->barcode_no)
+                            <div>{!! DNS1D::getBarcodeHTML($fabric->barcode_no, 'C39', 1, 33) !!}</div>
+                            <div class="text-xs">{{ $fabric->barcode_no }}</div>
+                        @else
+                            N/A
+                        @endif
                     </td>
                     <td class="py-3 px-6 text-left">
                         <div class="flex items-center">

--- a/resources/views/fabrics/print.blade.php
+++ b/resources/views/fabrics/print.blade.php
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Print Barcode - {{ $fabric->barcode_no }}</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            text-align: center;
+            padding: 20px;
+        }
+        .print-button {
+            padding: 10px 20px;
+            font-size: 16px;
+            cursor: pointer;
+            margin-top: 30px;
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 5px;
+        }
+        .barcode-container {
+            margin-bottom: 20px;
+        }
+        @media print {
+            .print-button {
+                display: none;
+            }
+            @page {
+                size: 3in 2in; /* Example size, can be adjusted */
+                margin: 0;
+            }
+            body {
+                margin: 0.5in;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="barcode-container">
+            @if ($fabric->barcode_no)
+                <div>{!! DNS1D::getBarcodeHTML($fabric->barcode_no, 'C39', 3, 90) !!}</div>
+                <p style="font-size: 24px; margin-top: 10px; letter-spacing: 2px;">{{ $fabric->barcode_no }}</p>
+            @else
+                <p>Barcode not available.</p>
+            @endif
+        </div>
+        <button onclick="window.print();" class="print-button">Print</button>
+    </div>
+</body>
+</html>

--- a/resources/views/fabrics/show.blade.php
+++ b/resources/views/fabrics/show.blade.php
@@ -35,15 +35,18 @@
 
         <div class="mt-6">
             <h2 class="text-xl font-semibold mb-4">Barcode</h2>
-            <div class="flex items-center">
-                <p class="text-gray-700 mr-4"><strong>Barcode:</strong> {{ $fabric->barcode }}</p>
-                {{-- Barcode generation and printing would require a library and more complex setup --}}
-                {{-- For now, just displaying the code and a placeholder button --}}
-                <button onclick="window.print()"
-                    class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded">
+            @if ($fabric->barcode_no)
+                <div class="mb-4">
+                    {!! DNS1D::getBarcodeHTML($fabric->barcode_no, 'C39', 2, 60) !!}
+                    <p class="text-center text-lg mt-2">{{ $fabric->barcode_no }}</p>
+                </div>
+                <a href="{{ route('admin.fabrics.print-barcode', $fabric) }}" target="_blank"
+                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
                     Print Barcode
-                </button>
-            </div>
+                </a>
+            @else
+                <p class="text-gray-700">No barcode generated for this fabric.</p>
+            @endif
         </div>
 
         <div class="mt-6">

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(
 
     // Fabric Routes
     Route::get('fabrics/trash', [FabricController::class, 'trash'])->name('fabrics.trash');
+    Route::get('fabrics/{fabric}/print-barcode', [FabricController::class, 'printBarcode'])->name('fabrics.print-barcode');
     Route::post('fabrics/{id}/restore', [FabricController::class, 'restore'])->name('fabrics.restore');
     Route::delete('fabrics/{id}/force-delete', [FabricController::class, 'forceDelete'])->name('fabrics.force-delete');
     Route::resource('fabrics', FabricController::class);


### PR DESCRIPTION
This commit implements a complete barcode generation and display system for the Fabric module.

Key features include:
- A new `barcode_no` field (e.g., `FBR-000001`) is automatically generated and saved for each new fabric.
- The `milon/barcode` package is used to render barcode images.
- Barcodes are displayed on the fabric index and details pages.
- A dedicated, printer-friendly page is added to print individual barcodes.

The implementation follows the existing Service and Repository pattern.

Note: The `milon/barcode` package needs to be installed (`composer require milon/barcode`) and database migrations need to be run (`php artisan migrate`) in the target environment.