### PR TITLE
Fix: Improve filters for supplier and fabric lists

### DIFF
--- a/app/Repositories/FabricRepository.php
+++ b/app/Repositories/FabricRepository.php
@@ -31,6 +31,15 @@ class FabricRepository
             $query->where('production_type', $request->input('production_type'));
         }
 
+        if ($request->filled('stock_status')) {
+            $stockStatus = $request->input('stock_status');
+            if ($stockStatus === 'in_stock') {
+                $query->havingRaw('(COALESCE(stock_in, 0) - COALESCE(stock_out, 0)) > 0');
+            } elseif ($stockStatus === 'out_of_stock') {
+                $query->havingRaw('(COALESCE(stock_in, 0) - COALESCE(stock_out, 0)) <= 0');
+            }
+        }
+
         return $query->paginate(10);
     }
 

--- a/app/Repositories/SupplierRepository.php
+++ b/app/Repositories/SupplierRepository.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 
 class SupplierRepository
 {
-    public function getAll(Request $request)
+    public function getAll($request)
     {
         $query = Supplier::query();
 
@@ -23,8 +23,12 @@ class SupplierRepository
             $query->where('country', 'like', '%' . $request->input('country') . '%');
         }
 
-        if ($request->has('start_date') && $request->has('end_date')) {
-            $query->whereBetween('created_at', [$request->input('start_date'), $request->input('end_date')]);
+        if ($request->filled('start_date')) {
+            $query->where('created_at', '>=', $request->input('start_date'));
+        }
+
+        if ($request->filled('end_date')) {
+            $query->where('created_at', '<=', $request->input('end_date'));
         }
 
         return $query->paginate(10);

--- a/app/Services/SupplierService.php
+++ b/app/Services/SupplierService.php
@@ -15,7 +15,7 @@ class SupplierService
         $this->supplierRepository = $supplierRepository;
     }
 
-    public function getSuppliers(Request $request)
+    public function getSuppliers($request)
     {
         return $this->supplierRepository->getAll($request);
     }

--- a/resources/views/fabrics/index.blade.php
+++ b/resources/views/fabrics/index.blade.php
@@ -22,7 +22,7 @@
         <summary class="font-semibold p-4 cursor-pointer">Advanced Search</summary>
         <div class="p-4 border-t">
             <form id="search-form" method="GET" action="{{ route('admin.fabrics.index') }}" class="space-y-4">
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
                     <div>
                         <label for="company_name" class="block text-sm font-medium text-gray-700">Company/Factory
                             Name</label>
@@ -53,6 +53,18 @@
                                 Woven</option>
                             <option value="non_woven" {{ request('production_type') == 'non_woven' ? 'selected' : '' }}>
                                 Non-Woven</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="stock_status" class="block text-sm font-medium text-gray-700">Stock
+                            Status</label>
+                        <select name="stock_status" id="stock_status"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                            <option value="">All</option>
+                            <option value="in_stock" {{ request('stock_status') == 'in_stock' ? 'selected' : '' }}>In Stock
+                            </option>
+                            <option value="out_of_stock"
+                                {{ request('stock_status') == 'out_of_stock' ? 'selected' : '' }}>Out of Stock</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
This commit addresses several issues with the filtering functionality on both the supplier and fabric list pages.

On the supplier list, the date filter has been improved to allow for open-ended date ranges. Previously, it required both a start and end date.

On the fabric list, a new "Stock Status" filter has been added to allow users to filter by "In Stock" or "Out of Stock", providing a much-needed inventory management feature.